### PR TITLE
directdownload: send Content-Length for folder downloads (fixes #707)

### DIFF
--- a/plugins/directdownload/src/main/kotlin/org/gameyfin/plugins/download/direct/DirectDownloadPlugin.kt
+++ b/plugins/directdownload/src/main/kotlin/org/gameyfin/plugins/download/direct/DirectDownloadPlugin.kt
@@ -12,10 +12,9 @@ import java.io.IOException
 import java.io.InputStream
 import java.io.PipedInputStream
 import java.io.PipedOutputStream
-import java.nio.file.*
-import java.nio.file.attribute.BasicFileAttributes
-import java.util.zip.ZipEntry
-import java.util.zip.ZipOutputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
 import kotlin.io.path.exists
 import kotlin.io.path.extension
 import kotlin.io.path.fileSize
@@ -48,18 +47,15 @@ class DirectDownloadPlugin(wrapper: PluginWrapper) : ConfigurableGameyfinPlugin(
         override fun download(path: Path): Download {
             if (!path.exists()) throw IllegalArgumentException("Path $path does not exist")
 
+            val isDirectory = path.isDirectory()
             return FileDownload(
-                data = streamContentAsSingleFile(path),
-                fileExtension = if (path.isDirectory()) "zip" else path.extension,
-                size = path.isDirectory().let {
-                    if (it) null else path.fileSize()
-                }
+                // Folders are packed as a STORED zip whose size is known up front, so the
+                // download advertises a Content-Length (browser shows size + progress bar).
+                // See StoredZip for the rationale and the ZIP64 handling.
+                data = if (isDirectory) StoredZip.stream(path) else streamFile(path),
+                fileExtension = if (isDirectory) "zip" else path.extension,
+                size = if (isDirectory) StoredZip.computeSize(path) else path.fileSize()
             )
-        }
-
-        fun streamContentAsSingleFile(path: Path): InputStream {
-            if (path.isDirectory()) return streamFolderAsZip(path)
-            return streamFile(path)
         }
 
         fun streamFile(path: Path): InputStream {
@@ -71,42 +67,6 @@ class DirectDownloadPlugin(wrapper: PluginWrapper) : ConfigurableGameyfinPlugin(
                     Files.newInputStream(path, StandardOpenOption.READ).use { input ->
                         input.copyTo(pipeOut, 512 * 1024)
                     }
-                } catch (_: IOException) {
-                } finally {
-                    try {
-                        pipeOut.close()
-                    } catch (_: IOException) {
-                    }
-                }
-            }
-
-            return pipeIn
-        }
-
-        fun streamFolderAsZip(path: Path): InputStream {
-            val pipeIn = PipedInputStream(512 * 1024) // 512 KB buffer
-            val pipeOut = PipedOutputStream(pipeIn)
-
-            Thread.ofVirtual().start {
-                try {
-                    ZipOutputStream(pipeOut).use { zos ->
-
-                        val compressionMode = plugin.config<CompressionMode>("compressionMode")
-                        zos.setLevel(compressionMode.deflaterLevel())
-
-                        Files.walkFileTree(path, object : SimpleFileVisitor<Path>() {
-                            override fun visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult {
-                                val entry = ZipEntry(path.relativize(file).toString())
-                                zos.putNextEntry(entry)
-                                Files.newInputStream(file, StandardOpenOption.READ).use { input ->
-                                    input.copyTo(zos, 512 * 1024)
-                                }
-                                zos.closeEntry()
-                                return FileVisitResult.CONTINUE
-                            }
-                        })
-                    }
-                    pipeOut.close()
                 } catch (_: IOException) {
                 } finally {
                     try {

--- a/plugins/directdownload/src/main/kotlin/org/gameyfin/plugins/download/direct/StoredZip.kt
+++ b/plugins/directdownload/src/main/kotlin/org/gameyfin/plugins/download/direct/StoredZip.kt
@@ -1,0 +1,228 @@
+package org.gameyfin.plugins.download.direct
+
+import java.io.BufferedOutputStream
+import java.io.File
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.zip.CRC32
+
+/**
+ * Packs a folder into a STORED (uncompressed) ZIP whose exact byte length can be
+ * computed up front, so a folder download can advertise a Content-Length.
+ *
+ * Why STORED: a DEFLATE stream's length is unknown until it finishes, so the original
+ * plugin sent no Content-Length for folder downloads (the browser showed "unknown size").
+ * STORED makes the archive length a pure function of the file sizes and names. Game
+ * payloads are already-compressed, so dropping DEFLATE costs ~no bandwidth.
+ *
+ * ZIP64 is added per-entry **only as needed** (a file >= 4 GiB, or a local-header offset
+ * past 4 GiB in a large archive) — forcing it onto every entry produces archives that
+ * modern unzip tools and JDK 22+ reject. [computeSize] and [stream] share the same layout
+ * helpers ([localExtraLen]/[centralExtraLen]/[needsZip64End]), so the advertised size is
+ * correct by construction.
+ */
+object StoredZip {
+
+    private const val ZIP64_MAGIC = 0xFFFFFFFFL   // value at/above this needs a ZIP64 field
+    private const val U16_MAX = 0xFFFF
+
+    private const val LOCAL_HEADER = 30L
+    private const val CENTRAL_HEADER = 46L
+    private const val EOCD = 22L
+    private const val ZIP64_EOCD = 56L
+    private const val ZIP64_LOCATOR = 20L
+
+    private class Entry(val file: Path, val name: ByteArray, val size: Long)
+
+    /** Bytes of the local-header ZIP64 extra field (id+len + uncompressed + compressed), or 0. */
+    private fun localExtraLen(size: Long): Long = if (size >= ZIP64_MAGIC) 20L else 0L
+
+    /** Bytes of the central-header ZIP64 extra field, holding only the fields that overflow. */
+    private fun centralExtraLen(size: Long, offset: Long): Long {
+        val sizeOver = size >= ZIP64_MAGIC
+        val offsetOver = offset >= ZIP64_MAGIC
+        if (!sizeOver && !offsetOver) return 0L
+        return 4L + (if (sizeOver) 16L else 0L) + (if (offsetOver) 8L else 0L)
+    }
+
+    private fun needsZip64End(count: Long, cdStart: Long, cdSize: Long): Boolean =
+        count >= U16_MAX || cdStart >= ZIP64_MAGIC || cdSize >= ZIP64_MAGIC
+
+    /** Exact number of bytes [stream] will emit for [root]. */
+    fun computeSize(root: Path): Long {
+        val entries = entries(root)
+        return plannedSize(entries.map { it.name.size }, entries.map { it.size })
+    }
+
+    /**
+     * Exact archive byte length for entries with the given name-byte lengths and file sizes,
+     * in order. Pure (no I/O) so the ZIP64 math is testable with synthetic multi-GB sizes.
+     * Must stay in lockstep with [writeArchive].
+     */
+    internal fun plannedSize(nameBytes: List<Int>, sizes: List<Long>): Long {
+        var offset = 0L
+        for (i in sizes.indices) offset += LOCAL_HEADER + nameBytes[i] + localExtraLen(sizes[i]) + sizes[i]
+        val cdStart = offset
+
+        var cdSize = 0L
+        var localOffset = 0L
+        for (i in sizes.indices) {
+            cdSize += CENTRAL_HEADER + nameBytes[i] + centralExtraLen(sizes[i], localOffset)
+            localOffset += LOCAL_HEADER + nameBytes[i] + localExtraLen(sizes[i]) + sizes[i]
+        }
+
+        val end = if (needsZip64End(sizes.size.toLong(), cdStart, cdSize)) ZIP64_EOCD + ZIP64_LOCATOR + EOCD else EOCD
+        return cdStart + cdSize + end
+    }
+
+    /** Streams [root] as a STORED zip on a virtual thread via a pipe. */
+    fun stream(root: Path): InputStream {
+        val pipeIn = PipedInputStream(512 * 1024)
+        val pipeOut = PipedOutputStream(pipeIn)
+        val entries = entries(root)
+
+        Thread.ofVirtual().start {
+            try {
+                BufferedOutputStream(pipeOut, 512 * 1024).use { out -> writeArchive(out, entries) }
+            } catch (_: IOException) {
+                // Client disconnected mid-download — nothing to do; pipe closed below.
+            } finally {
+                try {
+                    pipeOut.close()
+                } catch (_: IOException) {
+                }
+            }
+        }
+
+        return pipeIn
+    }
+
+    private class Central(val name: ByteArray, val crc: Long, val size: Long, val offset: Long)
+
+    private fun writeArchive(out: OutputStream, entries: List<Entry>) {
+        val centrals = ArrayList<Central>(entries.size)
+        var offset = 0L
+
+        // Local headers + file data
+        for (e in entries) {
+            val crc = crc32(e.file)
+            val zip64 = e.size >= ZIP64_MAGIC
+            out.u32(0x04034b50)                          // local file header signature
+            out.u16(if (zip64) 45 else 20)               // version needed
+            out.u16(0x0800)                              // flags: UTF-8 names
+            out.u16(0)                                   // method: STORED
+            out.u16(0); out.u16(0x21)                    // mod time / date (1980-01-01)
+            out.u32(crc)
+            out.u32(if (zip64) ZIP64_MAGIC else e.size)  // compressed size
+            out.u32(if (zip64) ZIP64_MAGIC else e.size)  // uncompressed size
+            out.u16(e.name.size)
+            out.u16(localExtraLen(e.size).toInt())
+            out.write(e.name)
+            if (zip64) { out.u16(1); out.u16(16); out.u64(e.size); out.u64(e.size) }
+
+            Files.newInputStream(e.file).use { input -> input.copyTo(out, 512 * 1024) }
+
+            centrals.add(Central(e.name, crc, e.size, offset))
+            offset += LOCAL_HEADER + e.name.size + localExtraLen(e.size) + e.size
+        }
+
+        // Central directory
+        val cdStart = offset
+        var cdSize = 0L
+        for (c in centrals) {
+            val sizeOver = c.size >= ZIP64_MAGIC
+            val offsetOver = c.offset >= ZIP64_MAGIC
+            val extra = centralExtraLen(c.size, c.offset)
+            out.u32(0x02014b50)                              // central file header signature
+            out.u16(45)                                      // version made by
+            out.u16(if (sizeOver || offsetOver) 45 else 20)  // version needed
+            out.u16(0x0800)                                  // flags: UTF-8 names
+            out.u16(0)                                       // method: STORED
+            out.u16(0); out.u16(0x21)                        // mod time / date
+            out.u32(c.crc)
+            out.u32(if (sizeOver) ZIP64_MAGIC else c.size)   // compressed size
+            out.u32(if (sizeOver) ZIP64_MAGIC else c.size)   // uncompressed size
+            out.u16(c.name.size)
+            out.u16(extra.toInt())
+            out.u16(0)                                       // comment length
+            out.u16(0)                                       // disk number start
+            out.u16(0)                                       // internal attributes
+            out.u32(0)                                       // external attributes
+            out.u32(if (offsetOver) ZIP64_MAGIC else c.offset)
+            out.write(c.name)
+            if (extra > 0) {
+                out.u16(1); out.u16((extra - 4).toInt())
+                if (sizeOver) { out.u64(c.size); out.u64(c.size) }
+                if (offsetOver) out.u64(c.offset)
+            }
+            cdSize += CENTRAL_HEADER + c.name.size + extra
+        }
+
+        // End-of-central-directory records
+        val count = centrals.size.toLong()
+        if (needsZip64End(count, cdStart, cdSize)) {
+            out.u32(0x06064b50)                  // ZIP64 end of central directory record
+            out.u64(44)                          // size of remainder of this record
+            out.u16(45); out.u16(45)             // version made by / needed
+            out.u32(0); out.u32(0)               // this disk / disk with CD start
+            out.u64(count); out.u64(count)       // entries on disk / total entries
+            out.u64(cdSize); out.u64(cdStart)    // size of CD / offset of CD
+            out.u32(0x07064b50)                  // ZIP64 end of central directory locator
+            out.u32(0)                           // disk with ZIP64 EOCD
+            out.u64(cdStart + cdSize)            // offset of ZIP64 EOCD
+            out.u32(1)                           // total number of disks
+        }
+        out.u32(0x06054b50)                      // end of central directory record
+        out.u16(0); out.u16(0)                   // this disk / disk with CD start
+        out.u16(if (count >= U16_MAX) U16_MAX else count.toInt())   // entries on disk
+        out.u16(if (count >= U16_MAX) U16_MAX else count.toInt())   // total entries
+        out.u32(if (cdSize >= ZIP64_MAGIC) ZIP64_MAGIC else cdSize)
+        out.u32(if (cdStart >= ZIP64_MAGIC) ZIP64_MAGIC else cdStart)
+        out.u16(0)                               // comment length
+    }
+
+    /** Regular files under [root], deterministically ordered. Empty directories are not entries. */
+    private fun entries(root: Path): List<Entry> {
+        val files = ArrayList<Path>()
+        Files.walk(root).use { stream ->
+            stream.filter { Files.isRegularFile(it) }.forEach { files.add(it) }
+        }
+        return files
+            .map { Entry(it, zipName(root, it).toByteArray(Charsets.UTF_8), Files.size(it)) }
+            .sortedWith(compareBy { String(it.name, Charsets.UTF_8) })
+    }
+
+    private fun zipName(root: Path, file: Path): String =
+        root.relativize(file).toString().replace(File.separatorChar, '/')
+
+    private fun crc32(file: Path): Long {
+        val crc = CRC32()
+        Files.newInputStream(file).use { input ->
+            val buf = ByteArray(512 * 1024)
+            while (true) {
+                val n = input.read(buf)
+                if (n < 0) break
+                crc.update(buf, 0, n)
+            }
+        }
+        return crc.value
+    }
+
+    private fun OutputStream.u16(v: Int) {
+        write(v and 0xFF); write((v ushr 8) and 0xFF)
+    }
+
+    private fun OutputStream.u32(v: Long) {
+        write((v and 0xFF).toInt()); write(((v ushr 8) and 0xFF).toInt())
+        write(((v ushr 16) and 0xFF).toInt()); write(((v ushr 24) and 0xFF).toInt())
+    }
+
+    private fun OutputStream.u64(v: Long) {
+        for (i in 0 until 8) write(((v ushr (8 * i)) and 0xFF).toInt())
+    }
+}

--- a/plugins/directdownload/src/main/resources/MANIFEST.MF
+++ b/plugins/directdownload/src/main/resources/MANIFEST.MF
@@ -1,4 +1,4 @@
-Plugin-Version: 1.0.2
+Plugin-Version: 1.0.3
 Plugin-Class: org.gameyfin.plugins.download.direct.DirectDownloadPlugin
 Plugin-Id: org.gameyfin.plugins.download.direct
 Plugin-Name: Direct Download

--- a/plugins/directdownload/src/test/kotlin/org/gameyfin/plugins/download/direct/StoredZipTest.kt
+++ b/plugins/directdownload/src/test/kotlin/org/gameyfin/plugins/download/direct/StoredZipTest.kt
@@ -1,0 +1,131 @@
+package org.gameyfin.plugins.download.direct
+
+import java.io.InputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.zip.ZipFile
+import java.util.zip.ZipInputStream
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeBytes
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class StoredZipTest {
+
+    private fun sampleTree(): Path {
+        val root = Files.createTempDirectory("gf-storedzip-")
+        root.resolve("readme.txt").writeBytes("hello world".toByteArray())
+        root.resolve("data").createDirectories()
+        root.resolve("data/level.dat").writeBytes(ByteArray(5000) { (it % 256).toByte() })
+        root.resolve("data/empty.bin").writeBytes(ByteArray(0))
+        root.resolve("café").createDirectories()            // non-ASCII path component
+        root.resolve("café/naïve.sav").writeBytes(ByteArray(123) { 7 })
+        return root
+    }
+
+    private fun countBytes(input: InputStream): Long {
+        var total = 0L
+        val buf = ByteArray(64 * 1024)
+        input.use { while (true) { val n = it.read(buf); if (n < 0) break; total += n } }
+        return total
+    }
+
+    /** The load-bearing test: a wrong Content-Length breaks downloads. */
+    @Test
+    fun `predicted size equals actual streamed bytes`() {
+        val root = sampleTree()
+        val predicted = StoredZip.computeSize(root)
+        val actual = countBytes(StoredZip.stream(root))
+        assertEquals(actual, predicted, "Content-Length predictor must match the bytes actually emitted")
+    }
+
+    @Test
+    fun `produced archive is a valid zip with correct entries and contents`() {
+        val root = sampleTree()
+        val expected = mapOf(
+            "readme.txt" to "hello world".toByteArray(),
+            "data/level.dat" to ByteArray(5000) { (it % 256).toByte() },
+            "data/empty.bin" to ByteArray(0),
+            "café/naïve.sav" to ByteArray(123) { 7 },
+        )
+        val seen = HashMap<String, ByteArray>()
+        ZipInputStream(StoredZip.stream(root)).use { zis ->
+            while (true) {
+                val e = zis.nextEntry ?: break
+                if (e.isDirectory) continue
+                seen[e.name] = zis.readBytes()
+            }
+        }
+        assertEquals(expected.keys, seen.keys)
+        for ((k, v) in expected) assertTrue(v.contentEquals(seen[k]), "content mismatch for $k")
+    }
+
+    /** Random-access open validates the central directory + (zip64) end-of-central-directory records. */
+    @Test
+    fun `archive parses via random-access ZipFile`() {
+        val root = sampleTree()
+        val tmp = Files.createTempFile("gf-zip-", ".zip")
+        StoredZip.stream(root).use { input -> Files.newOutputStream(tmp).use { input.copyTo(it) } }
+        ZipFile(tmp.toFile()).use { zf ->
+            val files = zf.entries().toList().filter { !it.isDirectory }
+            assertEquals(4, files.size)
+        }
+    }
+
+    @Test
+    fun `empty folder size is predicted exactly`() {
+        val root = Files.createTempDirectory("gf-storedzip-empty-")
+        assertEquals(countBytes(StoredZip.stream(root)), StoredZip.computeSize(root))
+    }
+
+    // --- ZIP64 layout math, exercised with synthetic sizes (no multi-GB I/O) ---
+
+    @Test
+    fun `planned size, no zip64`() {
+        // one entry: local(30+5+0+100) + central(46+5+0) + eocd(22)
+        assertEquals(208L, StoredZip.plannedSize(listOf(5), listOf(100L)))
+    }
+
+    @Test
+    fun `planned size, single file over 4GB triggers zip64 on size and end records`() {
+        // local 30+5+20+5e9 ; cd 46+5+20 ; +zip64eocd56 +loc20 +eocd22
+        assertEquals(5_000_000_224L, StoredZip.plannedSize(listOf(5), listOf(5_000_000_000L)))
+    }
+
+    @Test
+    fun `planned size, small file after 4GB gets zip64 offset field only`() {
+        // big(name5,5e9) then small(name5,10): the small entry's local offset > 4GB
+        // → central zip64 holds only the 8-byte offset (size fits in 32 bits).
+        assertEquals(5_000_000_332L, StoredZip.plannedSize(listOf(5, 5), listOf(5_000_000_000L, 10L)))
+    }
+
+    /**
+     * Real >4 GiB archive: validates the writer's ZIP64 path end to end (exact size +
+     * readability). Gated behind GAMEYFIN_BIGTEST=true because it moves multiple GiB.
+     */
+    @org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable(named = "GAMEYFIN_BIGTEST", matches = "true")
+    @Test
+    fun `archive over 4GB streams with exact size and stays readable`() {
+        val root = Files.createTempDirectory("gf-storedzip-big-")
+        val big = root.resolve("big.bin")
+        java.io.RandomAccessFile(big.toFile(), "rw").use { it.setLength(4_300_000_000L) } // sparse, > 4 GiB
+        root.resolve("after.txt").writeBytes("tail".toByteArray())
+
+        assertEquals(countBytes(StoredZip.stream(root)), StoredZip.computeSize(root))
+
+        var seenBig = false
+        var seenAfter = false
+        ZipInputStream(StoredZip.stream(root)).use { zis ->
+            while (true) {
+                val e = zis.nextEntry ?: break
+                when (e.name) {
+                    "big.bin" -> seenBig = true
+                    "after.txt" -> seenAfter = true
+                }
+                zis.closeEntry()
+            }
+        }
+        assertTrue(seenBig && seenAfter, "both entries present in the >4GB archive")
+    }
+}


### PR DESCRIPTION
## Summary

Folder downloads are served without a `Content-Length` header, so the browser shows "unknown size" and can't estimate progress (#707). This fixes that for folders while keeping archives compatible with strict extractors.

## Root cause

`DirectDownloadProvider.download()` already passes `Files.size()` for single files, so those downloads have always had `Content-Length`. For **directories** it passes `size = null`, because the on-the-fly `ZipOutputStream` length isn't known until the stream finishes. `DownloadEndpoint` sets `Content-Length` whenever `FileDownload.size` is non-null, so this is fixable entirely within the plugin — no core changes.

## Approach

Pack folders as a **STORED (uncompressed) zip** whose exact byte length is computed up front from the file sizes and names, and pass that as `FileDownload.size`.

- A new `StoredZip` object owns the archive layout. `computeSize()` (the predictor) and the writer share the same layout helpers, so the advertised size is **correct by construction** — there's no second formula to drift.
- **ZIP64 is emitted per-entry only as needed** (a file ≥ 4 GiB, or a local-header offset past 4 GiB in a large archive). Forcing ZIP64 onto every entry produces archives that JDK 22+ and some other extractors reject (`invalid zip64 extra data field size`), so the as-needed approach keeps output broadly compatible.
- Game payloads are already compressed, so dropping DEFLATE costs ~no bandwidth — and packing is noticeably faster.

## Tests

`StoredZipTest` covers:
- predicted size == actual emitted bytes for a nested tree (incl. a non-ASCII path), an empty folder;
- archive validity via `ZipInputStream` (contents) and random-access `ZipFile` (central directory / EOCD);
- the ZIP64 size math with synthetic multi-GB sizes (no I/O): single >4 GiB file, and a small file whose offset lands past 4 GiB (offset-only ZIP64 field);
- a real **>4 GiB** archive (exact size + readability), gated behind `GAMEYFIN_BIGTEST=true` so it doesn't slow the normal suite.

## Notes for review

- **`compressionMode` config:** folders are now always STORED, so this option no longer affects folder output. I left it in place to avoid a config-schema change, but I'm happy to either remove it or rework it into a "compress (no size) vs. STORED (with size)" toggle — whichever you prefer.
- **Version bump:** I bumped `Plugin-Version` to `1.0.3`; glad to drop that if you'd rather handle versioning.

Fixes #707.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
