### PR TITLE
Bugfix detached entity, fixes #904

### DIFF
--- a/app/src/main/kotlin/org/gameyfin/app/games/entities/Game.kt
+++ b/app/src/main/kotlin/org/gameyfin/app/games/entities/Game.kt
@@ -55,10 +55,10 @@ class Game(
 
     var criticRating: Int? = null,
 
-    @ManyToMany(cascade = [PERSIST, MERGE, REFRESH], fetch = FetchType.EAGER)
+    @ManyToMany(cascade = [MERGE, REFRESH], fetch = FetchType.EAGER)
     var publishers: MutableList<Company> = mutableListOf(),
 
-    @ManyToMany(cascade = [PERSIST, MERGE, REFRESH], fetch = FetchType.EAGER)
+    @ManyToMany(cascade = [MERGE, REFRESH], fetch = FetchType.EAGER)
     var developers: MutableList<Company> = mutableListOf(),
 
     @ElementCollection(targetClass = Genre::class, fetch = FetchType.EAGER)

--- a/app/src/main/kotlin/org/gameyfin/app/games/entities/Game.kt
+++ b/app/src/main/kotlin/org/gameyfin/app/games/entities/Game.kt
@@ -37,10 +37,10 @@ class Game(
 
     var title: String? = null,
 
-    @ManyToOne(cascade = [PERSIST, MERGE, REFRESH], fetch = FetchType.EAGER)
+    @ManyToOne(cascade = [MERGE, REFRESH], fetch = FetchType.EAGER)
     var coverImage: Image? = null,
 
-    @ManyToOne(cascade = [PERSIST, MERGE, REFRESH], fetch = FetchType.EAGER)
+    @ManyToOne(cascade = [MERGE, REFRESH], fetch = FetchType.EAGER)
     var headerImage: Image? = null,
 
     @Lob
@@ -76,7 +76,7 @@ class Game(
     @ElementCollection(targetClass = PlayerPerspective::class, fetch = FetchType.EAGER)
     var perspectives: List<PlayerPerspective> = emptyList(),
 
-    @ManyToMany(cascade = [PERSIST, MERGE, REFRESH], fetch = FetchType.EAGER)
+    @ManyToMany(cascade = [MERGE, REFRESH], fetch = FetchType.EAGER)
     var images: MutableList<Image> = mutableListOf(),
 
     @ElementCollection(fetch = FetchType.EAGER)


### PR DESCRIPTION
When a folder goes into the ignored paths you could not manually match metadata because it triggered the error: Detached entity passed to persist: org.gameyfin.app.media.Image

I can reproduce this with 2 folders that match with the same metadata, so also the same images. When you match the second folder with the same metadata it will also try to persist the images again, but those already exist so it triggers that error. I removed the persist, because 'merge' will also persist if it doesnt exists.
After that I got the error again, but for Company. I did the same for Company and now it seems to work fine.

