### PR TITLE
Add message of the day support

### DIFF
--- a/app/src/main/frontend/components/administration/SystemManagement.tsx
+++ b/app/src/main/frontend/components/administration/SystemManagement.tsx
@@ -3,6 +3,7 @@ import {SystemEndpoint} from "Frontend/generated/endpoints";
 import withConfigPage from "Frontend/components/administration/withConfigPage";
 import {addToast, Button} from "@heroui/react";
 import Section from "Frontend/components/general/Section";
+import TextAreaInput from "Frontend/components/general/input/TextAreaInput";
 
 function SystemManagementLayout() {
 
@@ -18,6 +19,9 @@ function SystemManagementLayout() {
 
     return (
         <div className="flex flex-col mt-4">
+            <Section title="Dashboard Server Message"/>
+            <TextAreaInput key="motd" name="motd" label="Server Message (HTML)"/>
+
             <Section title="Restart Gameyfin"/>
             <Button onPress={restart}>Restart</Button>
         </div>

--- a/app/src/main/frontend/views/HomeView.tsx
+++ b/app/src/main/frontend/views/HomeView.tsx
@@ -2,7 +2,7 @@ import {CoverRow} from "Frontend/components/general/covers/CoverRow";
 import {useSnapshot} from "valtio/react";
 import {libraryState} from "Frontend/state/LibraryState";
 import {gameState} from "Frontend/state/GameState";
-import React, {useMemo} from "react";
+import React, {useEffect, useMemo} from "react";
 import LibraryDto from "Frontend/generated/org/gameyfin/app/libraries/dto/LibraryDto";
 import {collectionState} from "Frontend/state/CollectionState";
 import CollectionDto from "Frontend/generated/org/gameyfin/app/collections/dto/CollectionDto";
@@ -11,6 +11,7 @@ import {Link, Spinner} from "@heroui/react";
 import {CaretRightIcon, FolderOpenIcon} from "@phosphor-icons/react";
 import {useAuth} from "Frontend/util/auth";
 import {isAdmin} from "Frontend/util/utils";
+import {configState, initializeConfigState} from "Frontend/state/ConfigState";
 
 export default function HomeView() {
     const auth = useAuth();
@@ -19,6 +20,14 @@ export default function HomeView() {
     const gamesState = useSnapshot(gameState);
     const gamesByLibrary = gamesState.gamesByLibraryId;
     const gamesByCollection = gamesState.gamesByCollectionId;
+
+    const config = useSnapshot(configState);
+
+    useEffect(() => {
+        initializeConfigState();
+    }, []);
+
+    const motd = config.config.motd as string | undefined;
 
     const filteredAndSortedLibraries = useMemo(() =>
         librariesState.sorted
@@ -78,31 +87,48 @@ export default function HomeView() {
 
     if (hasNoContent) {
         return (
-            <div className="flex flex-col items-center justify-center h-[70vh] text-center gap-4">
-                <FolderOpenIcon size={64} className="text-default-300"/>
-                <p className="text-xl font-semibold text-default-600">Nothing here yet</p>
-                {isAdmin(auth) ? (
-                    <>
-                        <p className="text-default-400 max-w-lg">
-                            Get started by adding libraries and games in the{" "}
-                            <Link href="/administration/games" underline="always">
-                                administration panel
-                            </Link>.
-                        </p>
-                    </>
-                ) : (
-                    <>
-                        <p className="text-default-400 max-w-md">
-                            There is currently no content available. Check back later!
-                        </p>
-                    </>
-                )}
-            </div>
+            <>
+                <div className="mb-4 max-w-3xl mx-auto rounded-lg border border-default-200 p-4">
+                    {motd ?
+                        <div className="text-justify" dangerouslySetInnerHTML={{__html: motd}}/> :
+                        <p>No message has been set.</p>
+                    }
+                </div>
+
+                <div className="flex flex-col items-center justify-center h-[70vh] text-center gap-4">
+                    <FolderOpenIcon size={64} className="text-default-300"/>
+                    <p className="text-xl font-semibold text-default-600">Nothing here yet</p>
+                    {isAdmin(auth) ? (
+                        <>
+                            <p className="text-default-400 max-w-lg">
+                                Get started by adding libraries and games in the{" "}
+                                <Link href="/administration/games" underline="always">
+                                    administration panel
+                                </Link>.
+                            </p>
+                        </>
+                    ) : (
+                        <>
+                            <p className="text-default-400 max-w-md">
+                                There is currently no content available. Check back later!
+                            </p>
+                        </>
+                    )}
+                </div>
+            </>
         );
     }
 
     return (
         <div className="w-full">
+
+            <div className="mb-4 max-w-3xl mx-auto rounded-lg border border-default-200 p-4">
+                {motd ?
+                    <div className="text-justify" dangerouslySetInnerHTML={{__html: motd}}/> :
+                    <p>No message has been set.</p>
+                }
+            </div>
+
             <div className="flex flex-col gap-4">
                 {(filteredAndSortedLibraries.length + filteredAndSortedCollections.length > 0) &&
                     <div className="flex flex-col gap-2">

--- a/app/src/main/kotlin/org/gameyfin/app/config/ConfigProperties.kt
+++ b/app/src/main/kotlin/org/gameyfin/app/config/ConfigProperties.kt
@@ -391,6 +391,17 @@ sealed class ConfigProperties<T : Serializable>(
             )
         }
     }
+
+    /** Dashboard Server Message */
+    sealed class General {
+        data object MessageOfTheDay : ConfigProperties<String>(
+            String::class,
+            "motd",
+            "Dashboard Server Message",
+            "Message shown to all users on the dashboard.",
+            ""
+        )
+    }
 }
 
 @Suppress("EnumEntryName")


### PR DESCRIPTION
## Overview

Adds a configurable Message of the Day (MOTD).

## Features

- MOTD configurable through Administration → System
- Stored using the existing configuration framework
- Displayed on the dashboard homepage
- Hidden when empty

## Implementation

- Added MOTD configuration property
- Added MOTD setting to System administration page
- Added dashboard display for configured MOTD
<img width="1571" height="925" alt="1" src="https://github.com/user-attachments/assets/8cdaf07c-e998-46dc-b89e-9ed0e7638b88" />
<img width="1608" height="1088" alt="2" src="https://github.com/user-attachments/assets/803369fa-9756-400e-bea1-c293cdbf0be5" />
<img width="1609" height="1083" alt="3" src="https://github.com/user-attachments/assets/eecde23f-f294-4628-a44d-05bf76fe9e10" />
<img width="1605" height="1085" alt="4" src="https://github.com/user-attachments/assets/b9bfc3ee-366f-4ef7-9a71-1a06451ccde9" />
